### PR TITLE
Add =~ and !~ operators and allow strings

### DIFF
--- a/expression.php
+++ b/expression.php
@@ -268,7 +268,6 @@ class Expression {
             } elseif ($ex and !$expecting_op) { // do we now have a function/variable/number?
                 $expecting_op = true;
                 $val = $match[1];
-                echo "$val\n";
                 if (preg_match("/^([a-z]\w*)\($/", $val, $matches)) { // may be func, or variable w/ implicit multiplication against parentheses...
                     if (in_array($matches[1], $this->fb) or array_key_exists($matches[1], $this->f)) { // it's a func
                         $stack->push($val);

--- a/expression.php
+++ b/expression.php
@@ -184,11 +184,13 @@ class Expression {
         
         $expecting_op = false; // we use this in syntax-checking the expression
                                // and determining when a - is a negation
-    
+
+        /* we allow all characters because of strings
         if (preg_match("%[^\w\s+*^\/()\.,-<>=&~|!\"\\\\/]%", $expr, $matches)) { // make sure the characters are all good
-        //    return $this->trigger("illegal character '{$matches[0]}'");
+            return $this->trigger("illegal character '{$matches[0]}'");
         }
-    
+        */
+
         while(1) { // 1 Infinite Loop ;)
             $op = substr($expr, $index, 2); // get the first two characters at the current index
             if (preg_match("/^[+\-*\/^_\"<>=()!~](?!=|~)/", $op) || preg_match("/\w/", $op)) {
@@ -196,7 +198,7 @@ class Expression {
                 $op = substr($expr, $index, 1);
             }
             // find out if we're currently at the beginning of a number/variable/function/parenthesis/operand
-            $ex = preg_match('/^("(?:[^"]|(?<=\\\\)")*"|[a-z]\w*\(?|\d+(?:\.\d*)?|\.\d+|\(|\$\w+)/', substr($expr, $index), $match);
+            $ex = preg_match('/^("(?:[^"]|(?<=\\\\)")*"|[\d.]+e\d+|[a-z]\w*\(?|\d+(?:\.\d*)?|\.\d+|\(|\$\w+)/', substr($expr, $index), $match);
             //===============
             if ($op == '!' && !$expecting_op) {
                 $stack->push('!'); // put a negation on the stack
@@ -266,6 +268,7 @@ class Expression {
             } elseif ($ex and !$expecting_op) { // do we now have a function/variable/number?
                 $expecting_op = true;
                 $val = $match[1];
+                echo "$val\n";
                 if (preg_match("/^([a-z]\w*)\($/", $val, $matches)) { // may be func, or variable w/ implicit multiplication against parentheses...
                     if (in_array($matches[1], $this->fb) or array_key_exists($matches[1], $this->f)) { // it's a func
                         $stack->push($val);

--- a/expression.php
+++ b/expression.php
@@ -171,31 +171,32 @@ class Expression {
     function nfx($expr) {
     
         $index = 0;
-        $stack = new EvalMathStack;
+        $stack = new ExpressionStack;
         $output = array(); // postfix form of expression, to be passed to pfx()
         $expr = trim(strtolower($expr));
         
-        $ops   = array('+', '-', '*', '/', '^', '_', '>', '<', '>=', '<=', '==', '!=', '&&', '||', '!');
+        $ops   = array('+', '-', '*', '/', '^', '_', '>', '<', '>=', '<=', '==', '!=', '=~', '!~', '&&', '||', '!');
         $ops_r = array('+'=>0,'-'=>0,'*'=>0,'/'=>0,'^'=>1,'>'=>0,
-                       '<'=>0,'>='=>0,'<='=>0,'=='=>0,'!='=>0,'&&'=>0,'||'=>0,'!'=>0); // right-associative operator?  
+                       '<'=>0,'>='=>0,'<='=>0,'=='=>0,'!='=>0,'=~'=>0,'!~'=>0,
+                       '&&'=>0,'||'=>0,'!'=>0); // right-associative operator?  
         $ops_p = array('+'=>4,'-'=>4,'*'=>4,'/'=>4,'_'=>4,'^'=>5,'>'=>2,'<'=>2,
-                       '>='=>2,'<='=>2,'=='=>2,'!='=>2,'&&'=>1,'||'=>1,'!'=>0); // operator precedence
+                       '>='=>2,'<='=>2,'=='=>2,'!='=>2,'=~'=>2,'!~'=>2,'&&'=>1,'||'=>1,'!'=>0); // operator precedence
         
         $expecting_op = false; // we use this in syntax-checking the expression
                                // and determining when a - is a negation
     
-        if (preg_match("/[^\w\s+*^\/()\.,-<>=&|!]/", $expr, $matches)) { // make sure the characters are all good
-            return $this->trigger("illegal character '{$matches[0]}'");
+        if (preg_match("%[^\w\s+*^\/()\.,-<>=&~|!\"\\\\/]%", $expr, $matches)) { // make sure the characters are all good
+        //    return $this->trigger("illegal character '{$matches[0]}'");
         }
     
         while(1) { // 1 Infinite Loop ;)
             $op = substr($expr, $index, 2); // get the first two characters at the current index
-            if (preg_match("/^[+\-*\/^_<>=()!](?!=)/", $op) || preg_match("/\w/", $op)) {
+            if (preg_match("/^[+\-*\/^_\"<>=()!~](?!=|~)/", $op) || preg_match("/\w/", $op)) {
                 // fix $op if it should have one character
                 $op = substr($expr, $index, 1);
             }
             // find out if we're currently at the beginning of a number/variable/function/parenthesis/operand
-            $ex = preg_match('/^([a-z]\w*\(?|\d+(?:\.\d*)?|\.\d+|\()/', substr($expr, $index), $match);
+            $ex = preg_match('/^("(?:[^"]|(?<=\\\\)")*"|[a-z]\w*\(?|\d+(?:\.\d*)?|\.\d+|\(|\$\w+)/', substr($expr, $index), $match);
             //===============
             if ($op == '!' && !$expecting_op) {
                 $stack->push('!'); // put a negation on the stack
@@ -213,6 +214,7 @@ class Expression {
                 // heart of the algorithm:
                 while($stack->count > 0 and ($o2 = $stack->last()) and in_array($o2, $ops) and ($ops_r[$op] ? $ops_p[$op] < $ops_p[$o2] : $ops_p[$op] <= $ops_p[$o2])) {
                     $output[] = $stack->pop(); // pop stuff off the stack into the output
+                    
                 }
                 // many thanks: http://en.wikipedia.org/wiki/Reverse_Polish_notation#The_algorithm_in_detail
                 $stack->push($op); // finally put OUR operator onto the stack
@@ -284,7 +286,6 @@ class Expression {
             } elseif (in_array($op, $ops) and !$expecting_op) {
                 return $this->trigger("unexpected operator '$op'");
             } else { // I don't even want to know what you did to get here
-                echo "$op\n";
                 return $this->trigger("an unexpected error occured");
             }
             if ($index == strlen($expr)) {
@@ -311,11 +312,10 @@ class Expression {
         
         if ($tokens == false) return false;
     
-        $stack = new EvalMathStack;
-        
+        $stack = new ExpressionStack();
         foreach ($tokens as $token) { // nice and easy
             // if the token is a binary operator, pop two values off the stack, do the operation, and push the result back on
-            if (in_array($token, array('+', '-', '*', '/', '^', '<', '>', '<=', '>=', '==', '&&', '||', '!='))) {
+            if (in_array($token, array('+', '-', '*', '/', '^', '<', '>', '<=', '>=', '==', '&&', '||', '!=', '=~', '!~'))) {
                 if (is_null($op2 = $stack->pop())) return $this->trigger("internal error");
                 if (is_null($op1 = $stack->pop())) return $this->trigger("internal error");
                 switch ($token) {
@@ -344,6 +344,17 @@ class Expression {
                         $stack->push($op1 != $op2); break;
                     case '&&':
                         $stack->push($op1 && $op2); break;
+                    case '=~':
+                    case '!~':
+                        if ($token == '=~') {
+                            $stack->push(preg_match($op2, $op1, $match));
+                        } else {
+                            $stack->push(!preg_match($op2, $op1, $match));
+                        }
+                        for ($i = 0; $i < count($match); $i++) {
+                            $this->v['$' . $i] = $match[$i];
+                        }
+                        break;
                     case '||':
                         $stack->push($op1 || $op2); break;
                 }
@@ -372,6 +383,8 @@ class Expression {
             } else {
                 if (is_numeric($token)) {
                     $stack->push($token);
+                } else if (preg_match('/^"(?:[^"]|(?<=\\\\)")*"$/', $token)) {
+                    $stack->push(json_decode($token));
                 } elseif (array_key_exists($token, $this->v)) {
                     $stack->push($this->v[$token]);
                 } elseif (array_key_exists($token, $vars)) {
@@ -395,7 +408,7 @@ class Expression {
 }
 
 // for internal use
-class EvalMathStack {
+class ExpressionStack {
 
     var $stack = array();
     var $count = 0;


### PR DESCRIPTION
I've added perl =~ and !~ operators and now you can compare agains strings, regexes need to be in quotes like in php but this can be changed.

You can merge but you need to resolve the conflict in your changes.
